### PR TITLE
Add Bootstrap Periodic

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -273,3 +273,28 @@ postsubmits:
           - --project=k8s-staging-test-infra
           - --env-passthrough=PULL_BASE_REF
           - triage/
+          
+periodics:
+  - name: periodic-test-infra-push-bootstrap
+    cluster: k8s-infra-prow-build-trusted
+    cron: "0 0 2 * *"
+    annotations:
+      testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
+      testgrid-tab-name: bootstrap
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: builds and pushes the bootstrap image
+    decorate: true
+    branches:
+    - ^master$
+    spec:
+      serviceAccountName: gcb-builder
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20230111-cd1b3caf9c
+        command:
+        - /run.sh
+        args:
+        - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+        - --project=k8s-staging-test-infra
+        - --build-dir=.
+        - images/bootstrap/


### PR DESCRIPTION
The bootstrap image can become stale if no changes are pushed and the gcloud sdk updates. This will at least publish once a month,